### PR TITLE
accept logrus.StdLogger interface instead of *log.Logger

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -6,6 +6,11 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.8.7-53-g446d1c1",
+			"Rev": "446d1c146faa8ed3f4218f056fcd165f6bcfda81"
+		},
+		{
 			"ImportPath": "github.com/asaskevich/govalidator",
 			"Comment": "v2-37-gedd46cd",
 			"Rev": "edd46cdac249b001c7b7d88c6d43993ea875e8d8"

--- a/api.go
+++ b/api.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
+
 	"goji.io"
 	"goji.io/pat"
 )
@@ -16,7 +18,7 @@ type API struct {
 	*goji.Mux
 	prefix    string
 	Resources map[string]*Resource
-	Logger    *log.Logger
+	Logger    logrus.StdLogger
 }
 
 // New initializes a new top level API Resource Handler. The most basic implementation
@@ -29,7 +31,7 @@ type API struct {
 //
 //	api := New("v1", log.New(os.Stdout, "apiV1: ", log.Ldate|log.Ltime|log.Lshortfile))
 //
-func New(prefix string, logger *log.Logger) *API {
+func New(prefix string, logger logrus.StdLogger) *API {
 
 	// ensure that our top level prefix is "/" prefixed
 	if !strings.HasPrefix(prefix, "/") {

--- a/resource.go
+++ b/resource.go
@@ -2,7 +2,6 @@ package jshapi
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"path"
 	"strings"
@@ -13,6 +12,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/derekdowling/go-json-spec-handler"
 	"github.com/derekdowling/jsh-api/store"
 )
@@ -52,7 +52,7 @@ type Resource struct {
 	// The singular name of the resource type("user", "post", etc)
 	Type string
 	// An implementation of Go's standard logger
-	Logger *log.Logger
+	Logger logrus.StdLogger
 	// Prefix is set if the resource is not the top level of URI, "/prefix/resources
 	Routes []string
 	// Map of relationships


### PR DESCRIPTION
allows us to use something like logrus or another logging library that implements StdLogger
