### PR TITLE
Removing magical pluralization of resource names

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,8 +12,8 @@
 		},
 		{
 			"ImportPath": "github.com/derekdowling/go-json-spec-handler",
-			"Comment": "0.7.3",
-			"Rev": "69ccb1741dff0309e3477cf35304146dec8b8744"
+			"Comment": "0.7.4",
+			"Rev": "37216022f1a23312ba9ebb6677f8bebfaa3f6477"
 		},
 		{
 			"ImportPath": "github.com/derekdowling/go-stdlogger",

--- a/Godeps/_workspace/src/github.com/derekdowling/go-json-spec-handler/client/client.go
+++ b/Godeps/_workspace/src/github.com/derekdowling/go-json-spec-handler/client/client.go
@@ -48,16 +48,17 @@ func buildParser(response *http.Response) *jsh.Parser {
 }
 
 /*
-setPath builds a JSON url.Path for a given resource type. Typically this just
-envolves concatting a pluralized resource name.
+setPath builds a JSON url.Path for a given resource type.
 */
 func setPath(url *url.URL, resource string) {
 
+	// ensure that path is "/" terminated before concatting resource
 	if url.Path != "" && !strings.HasSuffix(url.Path, "/") {
 		url.Path = url.Path + "/"
 	}
 
-	url.Path = fmt.Sprintf("%s%ss", url.Path, resource)
+	// don't pluralize resource automagically, JSON API spec is agnostic
+	url.Path = fmt.Sprintf("%s%s", url.Path, resource)
 }
 
 /*
@@ -67,6 +68,7 @@ ID specifier.
 func setIDPath(url *url.URL, resource string, id string) {
 	setPath(url, resource)
 
+	// concat "/:id" if not empty
 	if id != "" {
 		url.Path = strings.Join([]string{url.Path, id}, "/")
 	}

--- a/Godeps/_workspace/src/github.com/derekdowling/go-json-spec-handler/client/delete.go
+++ b/Godeps/_workspace/src/github.com/derekdowling/go-json-spec-handler/client/delete.go
@@ -35,7 +35,6 @@ func DeleteRequest(urlStr string, resourceType string, id string) (*http.Request
 		return nil, jsh.ISE(fmt.Sprintf("Error parsing URL: %s", err.Error()))
 	}
 
-	// ghetto pluralization, fix when it becomes an issue
 	setIDPath(u, resourceType, id)
 
 	request, err := http.NewRequest("DELETE", u.String(), nil)

--- a/Godeps/_workspace/src/github.com/derekdowling/go-json-spec-handler/client/post.go
+++ b/Godeps/_workspace/src/github.com/derekdowling/go-json-spec-handler/client/post.go
@@ -31,7 +31,6 @@ func PostRequest(baseURL string, object *jsh.Object) (*http.Request, error) {
 		return nil, fmt.Errorf("Error parsing URL: %s", err.Error())
 	}
 
-	// ghetto pluralization, fix when it becomes an issue
 	setPath(u, object.Type)
 
 	request, err := http.NewRequest("POST", u.String(), nil)

--- a/api.go
+++ b/api.go
@@ -58,12 +58,12 @@ func (a *API) Add(resource *Resource) {
 	// https://godoc.org/github.com/goji/goji/pat#hdr-Prefix_Matches
 	// We need two separate routes,
 	// /(prefix/)resources
-	matcher := path.Join(a.prefix, resource.PluralType())
+	matcher := path.Join(a.prefix, resource.Type)
 	a.Mux.HandleC(pat.New(matcher), resource)
 
 	// And:
 	// /(prefix/)resources/*
-	idMatcher := path.Join(a.prefix, resource.PluralType(), "*")
+	idMatcher := path.Join(a.prefix, resource.Type, "*")
 	a.Mux.HandleC(pat.New(idMatcher), resource)
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -14,7 +14,7 @@ func TestAPI(t *testing.T) {
 
 	Convey("API Tests", t, func() {
 
-		resourceType := "foo"
+		resourceType := "foos"
 		api := New("api")
 
 		So(api.prefix, ShouldEqual, "/api")

--- a/resource_test.go
+++ b/resource_test.go
@@ -23,7 +23,7 @@ func TestResource(t *testing.T) {
 			"foo": "bar",
 		}
 
-		resourceType := "foo"
+		resourceType := "foos"
 		resource := NewMockResource(resourceType, 2, attrs)
 
 		mux := goji.NewMux()
@@ -37,14 +37,12 @@ func TestResource(t *testing.T) {
 
 		Convey("->NewResource()", func() {
 
-			Convey("should properly handle a plural resource type", func() {
+			Convey("should be agnostic to plurality", func() {
 				resource := NewResource("users")
-				So(resource.Type, ShouldEqual, "user")
-			})
+				So(resource.Type, ShouldEqual, "users")
 
-			Convey("should properly handle a single resource type", func() {
-				resource := NewResource("user")
-				So(resource.Type, ShouldEqual, "user")
+				resource2 := NewResource("user")
+				So(resource2.Type, ShouldEqual, "user")
 			})
 		})
 
@@ -87,7 +85,7 @@ func TestResource(t *testing.T) {
 		Convey("->Delete()", func() {
 			resp, err := jsc.Delete(baseURL, resourceType, "1")
 
-			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+			So(resp.StatusCode, ShouldEqual, http.StatusNoContent)
 			So(err, ShouldBeNil)
 		})
 	})
@@ -101,7 +99,7 @@ func TestMutateHandler(t *testing.T) {
 			"foo": "bar",
 		}
 
-		resourceType := "bar"
+		resourceType := "bars"
 		resource := NewMockResource(resourceType, 2, attrs)
 
 		handler := func(ctx context.Context, id string) (*jsh.Object, jsh.ErrorType) {


### PR DESCRIPTION
Ran into this issue as well that is blocking for Ember-Data. Closes #12.
