### PR TITLE
Add context-aware leveled logging

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -44,3 +44,47 @@ func SendAndLog(ctx context.Context, w http.ResponseWriter, r *http.Request, sen
 		Logger.Printf("Error sending response: %s\n", sendErr.Error())
 	}
 }
+
+// LeveledLogger is a context-aware logger interface that differentiates between
+// log levels (debug, info, warning, error, critical).
+type LeveledLogger interface {
+	Debugf(ctx context.Context, format string, args ...interface{})
+	Infof(ctx context.Context, format string, args ...interface{})
+	Warningf(ctx context.Context, format string, args ...interface{})
+	Errorf(ctx context.Context, format string, args ...interface{})
+	Criticalf(ctx context.Context, format string, args ...interface{})
+}
+
+// StandardLogger is a leveled logger that calls Printf on an std.Logger for all
+// levels except debug. Debug logging can be turned on by setting Debug = true
+type StandardLogger struct {
+	std.Logger
+	Debug bool
+}
+
+// Debugf logs the message to the std.Logger using Printf only if Debug is true
+func (s *StandardLogger) Debugf(ctx context.Context, format string, args ...interface{}) {
+	if s.Debug {
+		s.Printf(format, args...)
+	}
+}
+
+// Infof redirects to Printf of std.Logger
+func (s *StandardLogger) Infof(ctx context.Context, format string, args ...interface{}) {
+	s.Printf(format, args...)
+}
+
+// Warningf redirects to Printf of std.Logger
+func (s *StandardLogger) Warningf(ctx context.Context, format string, args ...interface{}) {
+	s.Printf(format, args...)
+}
+
+// Errorf redirects to Printf of std.Logger
+func (s *StandardLogger) Errorf(ctx context.Context, format string, args ...interface{}) {
+	s.Printf(format, args...)
+}
+
+// Criticalf redirects to Printf of std.Logger
+func (s *StandardLogger) Criticalf(ctx context.Context, format string, args ...interface{}) {
+	s.Printf(format, args...)
+}

--- a/resource.go
+++ b/resource.go
@@ -55,6 +55,8 @@ type Resource struct {
 	Routes []string
 	// Map of relationships
 	Relationships map[string]Relationship
+
+	api *API
 }
 
 /*
@@ -252,17 +254,17 @@ func (res *Resource) Action(actionName string, storage store.Get) {
 func (res *Resource) postHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, storage store.Save) {
 	parsedObject, parseErr := jsh.ParseObject(r)
 	if parseErr != nil && reflect.ValueOf(parseErr).IsNil() == false {
-		SendAndLog(ctx, w, r, parseErr)
+		res.api.SendAndLog(ctx, w, r, parseErr)
 		return
 	}
 
 	object, err := storage(ctx, parsedObject)
 	if err != nil && reflect.ValueOf(err).IsNil() == false {
-		SendAndLog(ctx, w, r, err)
+		res.api.SendAndLog(ctx, w, r, err)
 		return
 	}
 
-	SendAndLog(ctx, w, r, object)
+	res.api.SendAndLog(ctx, w, r, object)
 }
 
 // GET /resources/:id
@@ -271,22 +273,22 @@ func (res *Resource) getHandler(ctx context.Context, w http.ResponseWriter, r *h
 
 	object, err := storage(ctx, id)
 	if err != nil && reflect.ValueOf(err).IsNil() == false {
-		SendAndLog(ctx, w, r, err)
+		res.api.SendAndLog(ctx, w, r, err)
 		return
 	}
 
-	SendAndLog(ctx, w, r, object)
+	res.api.SendAndLog(ctx, w, r, object)
 }
 
 // GET /resources
 func (res *Resource) listHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, storage store.List) {
 	list, err := storage(ctx)
 	if err != nil && reflect.ValueOf(err).IsNil() == false {
-		SendAndLog(ctx, w, r, err)
+		res.api.SendAndLog(ctx, w, r, err)
 		return
 	}
 
-	SendAndLog(ctx, w, r, list)
+	res.api.SendAndLog(ctx, w, r, list)
 }
 
 // DELETE /resources/:id
@@ -295,7 +297,7 @@ func (res *Resource) deleteHandler(ctx context.Context, w http.ResponseWriter, r
 
 	err := storage(ctx, id)
 	if err != nil && reflect.ValueOf(err).IsNil() == false {
-		SendAndLog(ctx, w, r, err)
+		res.api.SendAndLog(ctx, w, r, err)
 		return
 	}
 
@@ -306,17 +308,17 @@ func (res *Resource) deleteHandler(ctx context.Context, w http.ResponseWriter, r
 func (res *Resource) patchHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, storage store.Update) {
 	parsedObject, parseErr := jsh.ParseObject(r)
 	if parseErr != nil && reflect.ValueOf(parseErr).IsNil() == false {
-		SendAndLog(ctx, w, r, parseErr)
+		res.api.SendAndLog(ctx, w, r, parseErr)
 		return
 	}
 
 	object, err := storage(ctx, parsedObject)
 	if err != nil && reflect.ValueOf(err).IsNil() == false {
-		SendAndLog(ctx, w, r, err)
+		res.api.SendAndLog(ctx, w, r, err)
 		return
 	}
 
-	SendAndLog(ctx, w, r, object)
+	res.api.SendAndLog(ctx, w, r, object)
 }
 
 // GET /resources/:id/(relationships/)<resourceType>s
@@ -325,11 +327,11 @@ func (res *Resource) toManyHandler(ctx context.Context, w http.ResponseWriter, r
 
 	list, err := storage(ctx, id)
 	if err != nil && reflect.ValueOf(err).IsNil() == false {
-		SendAndLog(ctx, w, r, err)
+		res.api.SendAndLog(ctx, w, r, err)
 		return
 	}
 
-	SendAndLog(ctx, w, r, list)
+	res.api.SendAndLog(ctx, w, r, list)
 }
 
 // All HTTP Methods for /resources/:id/<mutate>
@@ -338,11 +340,11 @@ func (res *Resource) actionHandler(ctx context.Context, w http.ResponseWriter, r
 
 	response, err := storage(ctx, id)
 	if err != nil && reflect.ValueOf(err).IsNil() == false {
-		SendAndLog(ctx, w, r, err)
+		res.api.SendAndLog(ctx, w, r, err)
 		return
 	}
 
-	SendAndLog(ctx, w, r, response)
+	res.api.SendAndLog(ctx, w, r, response)
 }
 
 // addRoute adds the new method and route to a route Tree for debugging and


### PR DESCRIPTION
@derekdowling I adapted the logging mechanism in jsh-api to be context-aware and leveled, keeping it as backward-compatible as possible. This makes it a lot easier to write leveled logs on appengine and log important context variables.

I've also implemented full request/response (status, headers and body) goji logging middleware using this leveled logger, which I would be happy to share as well if you want it.
